### PR TITLE
Add left rotation, mobile DAS/ARR, and minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Icons taken from:
 - [x] Right/left static tetromino collision
 - [x] Right rotation
 - [x] Disallow auto rotate
-- [ ] Left rotation
+- [x] Left rotation
 - [x] Wall kicks
 - [x] Soft drop
 - [x] Soft drop - score
@@ -98,7 +98,7 @@ Icons taken from:
 - [ ] Hold tetromino
 - [ ] Switch held tetromino
 - [ ] Don't assume 60fps
-- [in-progress] Mobile controls
+- [x] Mobile controls
 - [x] Mobile layout/rendering
 - [x] Unit tests
 - [x] Web hosting


### PR DESCRIPTION
## Summary
- Add counterclockwise (left) rotation with split-screen tap zones on mobile (left half = CCW, right half = CW) and Z key on desktop
- Fix mobile DAS/ARR so sustained horizontal pans trigger auto-repeat instead of resetting every frame
- Remove duplicate `this.pan.isPanned` condition in `isShiftRightInputDown()`
- Mark mobile controls and left rotation as done in README

## Test plan
- [ ] Desktop: Z key rotates left, Up arrow rotates right (unchanged)
- [ ] Mobile: tap left half of screen rotates CCW, tap right half rotates CW
- [ ] Mobile: sustained horizontal pan triggers DAS/ARR (piece auto-repeats after delay)
- [ ] Mobile: releasing pan resets DAS/ARR counters
- [ ] `npm test` passes (55 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)