### PR TITLE
Add loading spinner and link commit badge to GitHub

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -10,15 +10,65 @@
     body {
       margin: 0;
       padding: 0;
-      background-color: black;
+      background-color: #D6EEFF;
+    }
+
+    #loading {
+      position: fixed;
+      inset: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: #D6EEFF;
+      z-index: 10000;
+      transition: opacity 0.3s;
+    }
+
+    #loading.hidden {
+      opacity: 0;
+      pointer-events: none;
+    }
+
+    .tetromino {
+      width: 60px;
+      height: 40px;
+      position: relative;
+      animation: spin 1s linear infinite;
+    }
+
+    .tetromino .block {
+      width: 20px;
+      height: 20px;
+      background: #922CE7;
+      border: 2px solid #481173;
+      box-sizing: border-box;
+      position: absolute;
+    }
+
+    .tetromino .b1 { left: 20px; top: 0; }
+    .tetromino .b2 { left: 0; top: 20px; }
+    .tetromino .b3 { left: 20px; top: 20px; }
+    .tetromino .b4 { left: 40px; top: 20px; }
+
+    @keyframes spin {
+      from { transform: rotate(0deg); }
+      to { transform: rotate(360deg); }
     }
   </style>
 </head>
 
 <body>
 
+  <div id="loading">
+    <div class="tetromino">
+      <div class="block b1"></div>
+      <div class="block b2"></div>
+      <div class="block b3"></div>
+      <div class="block b4"></div>
+    </div>
+  </div>
   <div id="game"></div>
-  <div id="commit-badge" style="position:fixed;bottom:8px;right:8px;font-size:10px;color:#aaa;font-family:monospace;z-index:9999;background:rgba(0,0,0,0.5);padding:2px 6px;border-radius:4px;"></div>
+  <a id="commit-badge" target="_blank" rel="noopener" style="position:fixed;bottom:8px;right:8px;font-size:10px;color:#aaa;font-family:monospace;z-index:9999;background:rgba(0,0,0,0.5);padding:2px 6px;border-radius:4px;text-decoration:none;"></a>
 
 </body>
 

--- a/src/index.js
+++ b/src/index.js
@@ -6,4 +6,6 @@ new Phaser.Game(Object.assign(config, {
   scene: [GameScene],
 }));
 
-document.getElementById("commit-badge").textContent = COMMIT_SHA.slice(0, 7);
+const badge = document.getElementById("commit-badge");
+badge.textContent = COMMIT_SHA.slice(0, 7);
+badge.href = "https://github.com/ryanggrey/tetris/commit/" + COMMIT_SHA;

--- a/src/scenes/Game.js
+++ b/src/scenes/Game.js
@@ -133,6 +133,12 @@ class Game extends Phaser.Scene {
     this.updateNextSection();
     this.spawnTetromino();
     this.gameOver = false;
+
+    const loading = document.getElementById("loading");
+    if (loading) {
+      loading.classList.add("hidden");
+      setTimeout(() => loading.remove(), 300);
+    }
   }
 
   createScoreSection() {


### PR DESCRIPTION
## Summary
- Show a spinning T-tetromino (CSS-only) while Phaser loads, fades out once the game scene creates
- Page background now matches game background (#D6EEFF) for a seamless transition
- Commit badge is now a link to the commit on GitHub

## Test plan
- [x] `npm test` — all 55 tests pass
- [x] `npm run build` — production build succeeds
- [ ] CI passes
- [ ] Amplify deploy succeeds
- [ ] Loading spinner visible on page load, disappears when game is ready
- [ ] Commit badge links to correct GitHub commit URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)